### PR TITLE
Normalizes ordering queries

### DIFF
--- a/routes/folders.js
+++ b/routes/folders.js
@@ -7,9 +7,17 @@ const router = express.Router();
 
 router.get('/', (req, res, next) => {
   const userId = req.user.id;
+  // Configure ?orderBy
+  const shouldOrderByColumn = req.query.orderBy || false;
+  // Configure ?orderDirection
+  const orderDirection = req.query.orderDirection || 'desc';
 
   Folder.query()
     .where({ userId })
+    .modify(queryBuilder => {
+      if (shouldOrderByColumn) queryBuilder.orderBy(shouldOrderByColumn, orderDirection);
+      return queryBuilder;
+    })
     .then(folders => {
       return res.json(folders);
     })

--- a/routes/folders.js
+++ b/routes/folders.js
@@ -11,12 +11,15 @@ router.get('/', (req, res, next) => {
   const shouldOrderByColumn = req.query.orderBy || false;
   // Configure ?orderDirection
   const orderDirection = req.query.orderDirection || 'desc';
+  // Configure ?limit
+  const limit = req.query.limit;
 
   Folder.query()
     .where({ userId })
-    .modify(queryBuilder => {
-      if (shouldOrderByColumn) queryBuilder.orderBy(shouldOrderByColumn, orderDirection);
-      return queryBuilder;
+    .modify(query => {
+      if (shouldOrderByColumn) query.orderBy(shouldOrderByColumn, orderDirection);
+      if (limit) query.limit(limit);
+      return query;
     })
     .then(folders => {
       return res.json(folders);

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -8,7 +8,12 @@ const router = express.Router();
 
 router.get('/', (req, res, next) => {
   const userId = req.user.id;
-  const { limit, orderBy } = req.query;
+  // Configure ?orderBy
+  const shouldOrderByColumn = req.query.orderBy || false;
+  // Configure ?orderDirection
+  const orderDirection = req.query.orderDirection || 'desc';
+  // Configure ?limit
+  const limit = req.query.limit;
 
   Topic.query()
     .select(
@@ -24,8 +29,8 @@ router.get('/', (req, res, next) => {
     .join('resources', 'topics.id', 'resources.parent')
     .where({ 'topics.userId': userId })
     .modify(query => {
+      if (shouldOrderByColumn) query.orderBy(shouldOrderByColumn, orderDirection);
       if (limit) query.limit(limit);
-      if (orderBy) query.orderBy(orderBy, 'desc');
       return query;
     })
     .then(results => {

--- a/routes/topics.js
+++ b/routes/topics.js
@@ -27,6 +27,8 @@ router.get('/', (req, res, next) => {
   const shouldOrderByColumn = req.query.orderBy || false;
   // Configure ?orderDirection
   const orderDirection = req.query.orderDirection || 'desc';
+  // Configure ?limit
+  const limit = req.query.limit;
 
   const userId = req.user.id;
   return Folder.query()
@@ -38,11 +40,12 @@ router.get('/', (req, res, next) => {
       'topics.updatedAt',
       'folders.title as folderTitle'
     )
-    .modify(queryBuilder => {
-      if (shouldSelectNotebooks) queryBuilder.select('topics.notebook as notebook');
-      if (shouldSelectResourceOrder) queryBuilder.select('topics.resourceOrder as resourceOrder');
-      if (shouldOrderByColumn) queryBuilder.orderBy(shouldOrderByColumn, orderDirection);
-      return queryBuilder;
+    .modify(query => {
+      if (shouldSelectNotebooks) query.select('topics.notebook as notebook');
+      if (shouldSelectResourceOrder) query.select('topics.resourceOrder as resourceOrder');
+      if (shouldOrderByColumn) query.orderBy(shouldOrderByColumn, orderDirection);
+      if (limit) query.limit(limit);
+      return query;
     })
     .rightJoin('topics', 'folders.id', 'topics.parent')
     .where({ 'topics.userId': userId })
@@ -76,11 +79,11 @@ router.get('/:id', (req, res, next) => {
       'folders.title as folderTitle'
     )
     .rightJoin('topics', 'folders.id', 'topics.parent')
-    .modify(queryBuilder => {
-      if (shouldShowNotebook) queryBuilder.select('topics.notebook as notebook');
-      if (shouldShowResourceOrder) queryBuilder.select('topics.resourceOrder as resourceOrder');
+    .modify(query => {
+      if (shouldShowNotebook) query.select('topics.notebook as notebook');
+      if (shouldShowResourceOrder) query.select('topics.resourceOrder as resourceOrder');
       if (shouldShowResources) {
-        queryBuilder
+        query
           .select(
             'resources.id as resourceId',
             'resources.title as resourceTitle',
@@ -91,7 +94,7 @@ router.get('/:id', (req, res, next) => {
           )
           .leftJoin('resources', 'topics.id', 'resources.parent');
       }
-      return queryBuilder;
+      return query;
     })
     .where({ 'topics.userId': userId, 'topics.id': topicId })
     .then(results => {

--- a/routes/topics.js
+++ b/routes/topics.js
@@ -23,6 +23,10 @@ router.get('/', (req, res, next) => {
   const shouldSelectNotebooks = req.query.notebooks || false;
   // Configure ?resourceOrder
   const shouldSelectResourceOrder = req.query.resourceOrder || false;
+  // Configure ?orderBy
+  const shouldOrderByColumn = req.query.orderBy || false;
+  // Configure ?orderDirection
+  const orderDirection = req.query.orderDirection || 'desc';
 
   const userId = req.user.id;
   return Folder.query()
@@ -37,6 +41,7 @@ router.get('/', (req, res, next) => {
     .modify(queryBuilder => {
       if (shouldSelectNotebooks) queryBuilder.select('topics.notebook as notebook');
       if (shouldSelectResourceOrder) queryBuilder.select('topics.resourceOrder as resourceOrder');
+      if (shouldOrderByColumn) queryBuilder.orderBy(shouldOrderByColumn, orderDirection);
       return queryBuilder;
     })
     .rightJoin('topics', 'folders.id', 'topics.parent')


### PR DESCRIPTION
Now all GET / endpoints have the query params `orderBy`, `orderDirection`, and also `limit`. Necessary for work on the front-end to proceed.